### PR TITLE
Add nightly build for tidal-gui and update README.md

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,68 @@
+name: Tidal Media Downloader
+
+on: [push, pull_request]
+
+jobs:
+  Build:
+    name: Build tidal-gui
+    runs-on: windows-latest
+
+    steps:
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Checkout Tidal-Media-Downloader-PRO repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: Tidal-Media-Downloader-PRO
+
+    - name: Checkout TidalLib repo
+      uses: actions/checkout@v2
+      with:
+        repository: yaronzz/TidalLib
+        path: TidalLib
+
+    - name: Checkout AIGS repo
+      uses: actions/checkout@v2
+      with:
+        repository: AIGMix/AIGS
+        path: AIGS
+
+    - name: Patch AIGS.csproj artifact
+      run: |
+        $File = "AIGS.csproj"
+        (Get-Content $File) -replace "v4.6.1", "v4.8" | Set-Content $File
+        (Get-Content $File) -replace [regex]::escape('..\Suda\Suda\'), "" | Set-Content $File
+      working-directory: AIGS
+
+    - name: Intall AIGS dependencies
+      run: msbuild -t:restore -p:RestorePackagesConfig=true
+      working-directory: AIGS
+
+    - name: Intall TidalLib dependencies
+      run: msbuild -t:restore -p:RestorePackagesConfig=true
+      working-directory: TidalLib\TidalLib
+
+    - name: Intall TIDALDL-UI-PRO dependencies
+      run: msbuild -t:restore -p:RestorePackagesConfig=true
+      working-directory: Tidal-Media-Downloader-PRO\TIDALDL-UI-PRO
+
+    - name: Build AIGS artifact
+      run: msbuild AIGS.csproj -verbosity:diag -property:Configuration=Debug
+      working-directory: AIGS
+
+    - name: Build TidalLib artifact
+      run: msbuild TidalLib.csproj -verbosity:diag -property:Configuration=Debug
+      working-directory: TidalLib\TidalLib
+
+    - name: Build tidal-gui artifact
+      run: msbuild TIDALDL-UI.csproj -verbosity:diag -property:Configuration=Release
+      working-directory: Tidal-Media-Downloader-PRO\TIDALDL-UI-PRO
+
+    - name: Upload tidal-gui artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: tidal-gui
+        path: Tidal-Media-Downloader-PRO\TIDALDL-UI-PRO\bin\Release\tidal-gui.exe
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@
 | tidal-gui      | Windows                           | [tidal-gui.exe](https://github.com/yaronzz/Tidal-Media-Downloader-PRO/releases) |
 | tidal-dl (cli) | Windows \ Linux \ Macos \ Android | ```pip3 install tidal-dl --upgrade```<br />[Detailed Description](https://yaronzz.com/post/tidal_dl_installation/#Install) |
 
+### Nightly Builds
+
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/yaronzz/Tidal-Media-Downloader-PRO/actions/workflows/continuous-integration-workflow.yml
+[Build]: https://github.com/yaronzz/Tidal-Media-Downloader-PRO/actions/workflows/continuous-integration-workflow.yml/badge.svg
+
+
 ## 📡 Telegram
 
 - [Group](https://t.me/tidal_group) : Feed back


### PR DESCRIPTION
@yaronzz I've managed to add the Github Workflow CI/CD pipeline for the tidal-gui software.
Here you can see a succesful run: https://github.com/bladeoner/Tidal-Media-Downloader-PRO/actions/runs/1915567588
The artifact is also available.

You can add this PR if you want.

To get this to work I had to patch two files, if you can add the following PRs I can remove the patches.
- https://github.com/AIGMix/AIGS/pull/2
- https://github.com/AIGMix/AIGS/pull/3
- https://github.com/yaronzz/TidalLib/pull/6

I also opened a few other PRs to add a Github Workflow CI/CD pipeline for TidalLib and AIGS which uses the same patches as above and can be removed after adding the above PRs. Furthermore I updated the Tidal-Media-Downloader workflow.
- https://github.com/yaronzz/Tidal-Media-Downloader/pull/870
- https://github.com/yaronzz/TidalLib/pull/7
Succesful run: https://github.com/bladeoner/TidalLib/actions/runs/1915638190
- https://github.com/AIGMix/AIGS/pull/4
Succesful run: https://github.com/bladeoner/AIGS/actions/runs/1915707060

And I've added the Dutch language:
- https://github.com/yaronzz/Tidal-Media-Downloader/pull/871
