### PR TITLE
Pad Track Number more in playlist export

### DIFF
--- a/TIDALDL-UI-PRO/Else/Tools.cs
+++ b/TIDALDL-UI-PRO/Else/Tools.cs
@@ -129,7 +129,7 @@ namespace TIDALDL_UI.Else
         {
             string number = track.TrackNumber.ToString().PadLeft(2, '0');
             if (playlist != null)
-                number = (playlist.Tracks.IndexOf(track) + 1).ToString().PadLeft(2, '0');
+                number = (playlist.Tracks.IndexOf(track) + 1).ToString().PadLeft(4, '0');
 
             string artist = FormatPath(string.Join(", ", track.Artists.Select(an_artist => an_artist.Name)), settings, false);
 


### PR DESCRIPTION
2 zeros is not enough padding to sort playlists when the player does not use natural number sorting. I recommend bumping this up to 4 or automatically adapting to the size of the playlist.